### PR TITLE
[FIX] : 🔧: 북마크 삭제 오류

### DIFF
--- a/app/src/main/java/com/example/assignmnet_img/search/SearchFragment.kt
+++ b/app/src/main/java/com/example/assignmnet_img/search/SearchFragment.kt
@@ -109,7 +109,7 @@ class SearchFragment : Fragment() {
             liveBookMarkModel.observe(viewLifecycleOwner){
                 val updateItem = liveBookMarkModel.value?.toSearchModel()
 
-                viewModel.updateItem(updateItem)
+                viewModel.compareUpdateItem(updateItem)
             }
         }
 
@@ -119,10 +119,6 @@ class SearchFragment : Fragment() {
     private fun updateItem(item: SearchModel) = with(sharedViewModel) {
 
         sharedViewModel.updateSearchModel(item)
-//        liveSearchModel.value = item
-        // viewmodel안에 메소드화 하기
-        // 캡슐화,은닉화
-        // 뷰 모델
 
     }
 

--- a/app/src/main/java/com/example/assignmnet_img/search/viewmdoel/SearchViewModel.kt
+++ b/app/src/main/java/com/example/assignmnet_img/search/viewmdoel/SearchViewModel.kt
@@ -11,15 +11,25 @@ class SearchViewModel() : ViewModel() {
     private val _searchList: MutableLiveData<List<SearchModel>> = MutableLiveData()
     val searchList: LiveData<List<SearchModel>> get() = _searchList
 
+    private fun findItem(item: SearchModel?): SearchModel? {
+        val currentList = searchList.value.orEmpty()
+
+        if (item != null) {
+            return currentList.find {
+                it.datetime == item.datetime &&
+                        it.imageUrl == item.imageUrl &&
+                        it.displaySiteName == item.displaySiteName
+            }
+        }
+        return null
+    }
+
+
     private fun findIndex(item: SearchModel?): Int {
 
         val currentList = searchList.value.orEmpty().toMutableList()
 
-        val findItem = currentList.find {
-            it.datetime == item?.datetime &&
-                    it.imageUrl == item.imageUrl &&
-                    it.displaySiteName == item.displaySiteName
-        }
+        val findItem = findItem(item)
 
         return currentList.indexOf(findItem)
 
@@ -41,6 +51,14 @@ class SearchViewModel() : ViewModel() {
         currentList[index] = item
 
         _searchList.value = currentList
+    }
+
+    fun compareUpdateItem(item: SearchModel?) {
+        if (item == null) return
+        val currentList = searchList.value.orEmpty().toMutableList()
+        if (findItem(item) == null) return
+        else updateItem(item)
+
     }
 
 


### PR DESCRIPTION
재검색 이후 북마크 삭제되는 오류를 고쳤습니다.

원인

재검색 이후 해당 리스트가 없는데도 아이템 update 메소드가 발동되어 문제가 생겼습니다.
따라서 비교를 위한 메소드를 하나 생성하여 적용했습니다.